### PR TITLE
chore: bump reporter + retriever charts to 1.0.20

### DIFF
--- a/charts/reporter/Chart.yaml
+++ b/charts/reporter/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     name: log10x
 name: reporter-10x
 type: application
-version: 1.0.15
-appVersion: 1.0.19
+version: 1.0.20
+appVersion: 1.0.20

--- a/charts/retriever/Chart.yaml
+++ b/charts/retriever/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     name: log10x
 name: retriever-10x
 type: application
-version: 1.0.13
-appVersion: 1.0.13
+version: 1.0.20
+appVersion: 1.0.20


### PR DESCRIPTION
appVersion drives the default Log10x image tag in both charts, so this aligns the default sidecar image with the 1.0.20 release.