### PR TITLE
retriever: Azure Monitor Logs output for fetch-back

### DIFF
--- a/charts/retriever/Chart.yaml
+++ b/charts/retriever/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     name: log10x
 name: retriever-10x
 type: application
-version: 1.0.20
+version: 1.0.21
 appVersion: 1.0.20

--- a/charts/retriever/README.md
+++ b/charts/retriever/README.md
@@ -9,7 +9,7 @@ This chart deploys one or more **cluster deployments** with specific roles for p
 - **Query**: Process query requests and generate sub-queries
 - **Stream**: Execute stream tasks from SQS and forward results to configured destinations
 
-Stream workers automatically include a **fluent-bit sidecar** for log forwarding to destinations like S3, CloudWatch, Elasticsearch, Splunk, or Datadog.
+Stream workers automatically include a **fluent-bit sidecar** for log forwarding to destinations like S3, CloudWatch, Elasticsearch, Splunk, Datadog, or Azure Monitor.
 
 ## Prerequisites
 
@@ -93,7 +93,7 @@ clusters:
 # Fluent-bit configuration for stream workers
 fluentBit:
   output:
-    type: s3  # Options: stdout, s3, cloudwatch, elasticsearch, splunk, datadog
+    type: s3  # Options: stdout, s3, cloudwatch, elasticsearch, splunk, datadog, azure
     config:
       s3:
         bucket: my-logs-bucket
@@ -141,17 +141,20 @@ Stream workers automatically deploy a fluent-bit sidecar for log forwarding.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `fluentBit.output.type` | Output destination: `stdout`, `s3`, `cloudwatch`, `elasticsearch`, `splunk`, `datadog` | `stdout` |
+| `fluentBit.output.type` | Output destination: `stdout`, `s3`, `cloudwatch`, `elasticsearch`, `splunk`, `datadog`, `azure` | `stdout` |
 | `fluentBit.output.config.s3.bucket` | S3 bucket name (for S3 output) | `""` |
 | `fluentBit.output.config.cloudwatch.logGroupName` | CloudWatch log group (for CloudWatch output) | `""` |
 | `fluentBit.output.config.elasticsearch.host` | Elasticsearch host (for ES output) | `""` |
 | `fluentBit.output.config.splunk.host` | Splunk HEC endpoint (for Splunk output) | `""` |
 | `fluentBit.output.config.datadog.apiKey` | Datadog API key (for Datadog output) | `""` |
+| `fluentBit.output.config.azure.streamName` | Azure Monitor: BARE table name, e.g. `Tenx_CL` (the `azure_logs_ingestion` plugin derives the `Custom-<table>` DCR stream) | `""` |
+| `fluentBit.output.config.azure.dceUrl` / `.dcrId` | Azure Monitor Data Collection Endpoint URL / immutable DCR id | `""` |
+| `fluentBit.output.config.azure.tenantId` / `.clientId` / `.clientSecret` | Entra app credentials (clientSecret via secret → `AZURE_CLIENT_SECRET`) | `""` |
 | `fluentBit.bufferStorageSize` | Max buffer disk space | `1Gi` |
 
 **Authentication:**
 - **S3/CloudWatch**: Uses IRSA (configure via `serviceAccount.annotations`)
-- **Elasticsearch/Splunk/Datadog**: Uses Kubernetes secrets (provide credentials via `--set-string`)
+- **Elasticsearch/Splunk/Datadog/Azure**: Uses Kubernetes secrets (provide credentials via `--set-string`; Azure uses `config.azure.clientSecret`)
 
 Example with CloudWatch:
 

--- a/charts/retriever/templates/configmap-fluent.yaml
+++ b/charts/retriever/templates/configmap-fluent.yaml
@@ -81,6 +81,18 @@ data:
         dd_service   {{ .Values.fluentBit.output.config.datadog.service | default "log10x-retriever" }}
         dd_source    {{ .Values.fluentBit.output.config.datadog.source | default "log10x" }}
         retry_limit  3
+    {{- else if eq .Values.fluentBit.output.type "azure" }}
+    [OUTPUT]
+        Name          azure_logs_ingestion
+        Match         *
+        tenant_id     {{ .Values.fluentBit.output.config.azure.tenantId }}
+        client_id     {{ .Values.fluentBit.output.config.azure.clientId }}
+        client_secret ${AZURE_CLIENT_SECRET}
+        dce_url       {{ .Values.fluentBit.output.config.azure.dceUrl }}
+        dcr_id        {{ .Values.fluentBit.output.config.azure.dcrId }}
+        table_name    {{ .Values.fluentBit.output.config.azure.streamName }}
+        time_generated On
+        retry_limit   3
     {{- else }}
     # Default output: stdout (useful for debugging and log aggregation)
     [OUTPUT]

--- a/charts/retriever/templates/deployment.yaml
+++ b/charts/retriever/templates/deployment.yaml
@@ -149,7 +149,7 @@ spec:
             - name: metrics
               containerPort: 2020
               protocol: TCP
-          {{- if or (eq $.Values.fluentBit.output.type "splunk") (eq $.Values.fluentBit.output.type "datadog") (eq $.Values.fluentBit.output.type "elasticsearch") }}
+          {{- if or (eq $.Values.fluentBit.output.type "splunk") (eq $.Values.fluentBit.output.type "datadog") (eq $.Values.fluentBit.output.type "elasticsearch") (eq $.Values.fluentBit.output.type "azure") }}
           env:
           {{- if eq $.Values.fluentBit.output.type "splunk" }}
             - name: SPLUNK_TOKEN
@@ -174,6 +174,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "log10x-retriever.fullname" $ }}-fluent-secrets
                   key: elasticsearch-password
+          {{- else if eq $.Values.fluentBit.output.type "azure" }}
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "log10x-retriever.fullname" $ }}-fluent-secrets
+                  key: azure-client-secret
           {{- end }}
           {{- end }}
           livenessProbe:

--- a/charts/retriever/templates/secret-fluent.yaml
+++ b/charts/retriever/templates/secret-fluent.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.fluentBit.output.type "splunk") (eq .Values.fluentBit.output.type "datadog") (eq .Values.fluentBit.output.type "elasticsearch") }}
+{{- if or (eq .Values.fluentBit.output.type "splunk") (eq .Values.fluentBit.output.type "datadog") (eq .Values.fluentBit.output.type "elasticsearch") (eq .Values.fluentBit.output.type "azure") }}
 {{- $hasStreamWorker := false }}
 {{- range .Values.clusters }}
   {{- if has "stream" .roles }}
@@ -36,6 +36,12 @@ data:
   elasticsearch-password: {{ .Values.fluentBit.output.config.elasticsearch.httpPasswd | b64enc | quote }}
   {{- else }}
   elasticsearch-password: ""  # Must be provided via --set-string fluentBit.output.config.elasticsearch.httpPasswd=<password>
+  {{- end }}
+  {{- else if eq .Values.fluentBit.output.type "azure" }}
+  {{- if .Values.fluentBit.output.config.azure.clientSecret }}
+  azure-client-secret: {{ .Values.fluentBit.output.config.azure.clientSecret | b64enc | quote }}
+  {{- else }}
+  azure-client-secret: ""  # Must be provided via --set-string fluentBit.output.config.azure.clientSecret=<secret>
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/retriever/templates/validation.yaml
+++ b/charts/retriever/templates/validation.yaml
@@ -5,7 +5,7 @@
   {{- end }}
 {{- end }}
 {{- if $hasStreamWorker }}
-{{- $validOutputs := list "stdout" "s3" "cloudwatch" "elasticsearch" "splunk" "datadog" }}
+{{- $validOutputs := list "stdout" "s3" "cloudwatch" "elasticsearch" "splunk" "datadog" "azure" }}
 {{- if .Values.fluentBit.output.type }}
   {{- if not (has .Values.fluentBit.output.type $validOutputs) }}
     {{- fail (printf "fluentBit.output.type '%s' is not valid. Must be one of: %s" .Values.fluentBit.output.type (join ", " $validOutputs)) }}

--- a/charts/retriever/values.yaml
+++ b/charts/retriever/values.yaml
@@ -474,7 +474,8 @@ fluentBit:
         clientSecret: ""  # Provide via --set-string fluentBit.output.config.azure.clientSecret=<secret>
         dceUrl: ""        # https://<dce>.<region>.ingest.monitor.azure.com
         dcrId: ""         # immutable Data Collection Rule id
-        streamName: ""    # DCR stream / table name (e.g. Custom-Tenx_CL)
+        streamName: ""    # BARE table name, e.g. Tenx_CL. The plugin sends to the DCR
+                          # stream Custom-<streamName>, so do NOT prefix with Custom-.
 
   # Advanced: Provide raw fluent-bit configuration
   # This overrides the output configuration above

--- a/charts/retriever/values.yaml
+++ b/charts/retriever/values.yaml
@@ -410,10 +410,10 @@ fluentBit:
 
   # Output configuration
   # This determines WHERE query results are delivered to users
-  # Available types: stdout, s3, cloudwatch, elasticsearch, splunk, datadog
+  # Available types: stdout, s3, cloudwatch, elasticsearch, splunk, datadog, azure
   output:
     # Output type - leave empty or set to "stdout" for default
-    # Must be one of: stdout, s3, cloudwatch, elasticsearch, splunk, datadog
+    # Must be one of: stdout, s3, cloudwatch, elasticsearch, splunk, datadog, azure
     type: stdout
 
     # Type-specific configuration (only used when type is not stdout)
@@ -464,6 +464,17 @@ fluentBit:
         apiKey: ""  # Provide via --set-string fluentBit.output.config.datadog.apiKey=<key>
         service: log10x-retriever
         source: log10x
+
+      # Azure Monitor Logs output configuration (used when type: azure)
+      # Sends via the Logs Ingestion API (DCE -> DCR -> table); supports Basic/Auxiliary plans.
+      # Authentication: Entra app; clientSecret stored in a secret (AZURE_CLIENT_SECRET env).
+      azure:
+        tenantId: ""
+        clientId: ""
+        clientSecret: ""  # Provide via --set-string fluentBit.output.config.azure.clientSecret=<secret>
+        dceUrl: ""        # https://<dce>.<region>.ingest.monitor.azure.com
+        dcrId: ""         # immutable Data Collection Rule id
+        streamName: ""    # DCR stream / table name (e.g. Custom-Tenx_CL)
 
   # Advanced: Provide raw fluent-bit configuration
   # This overrides the output configuration above


### PR DESCRIPTION
Adds `azure` as a Retriever `fluentBit.output.type`, so offloaded events fetched back from your bucket can be shipped to Azure Monitor Logs (completing Azure destination support alongside the tier_down work).

- `configmap-fluent.yaml`: `azure_logs_ingestion` output branch (Logs Ingestion API via DCE/DCR).
- `secret-fluent.yaml` + `deployment.yaml`: the Entra client secret is stored in the fluent secret and injected as `AZURE_CLIENT_SECRET`.
- `values.yaml`: `fluentBit.output.config.azure` block (tenantId/clientId/clientSecret/dceUrl/dcrId/streamName) + type-enum comments.
- `validation.yaml`: `azure` added to the output-type allowlist.

Validated with `helm template --set fluentBit.output.type=azure` (renders clean, exit 0) and `helm lint` (passes). Datadog/other outputs unchanged.

Companion to log-10x/log10x-mcp#128, log-10x/config#50, log-10x/mksite#120, log-10x/modules#65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)